### PR TITLE
Update launch.json for .NET 6

### DIFF
--- a/RazorSvelte/.vscode/launch.json
+++ b/RazorSvelte/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net5.0/RazorSvelte.dll",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/RazorSvelte.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,


### PR DESCRIPTION
Since the default framework is .NET 6, the launch.json should also reference the .net6.0 folder.