### PR TITLE
Nest *.cshtml.cs, *.entry.ts and *.rollup.config.js in VSCode

### DIFF
--- a/RazorSvelte/.vscode/settings.json
+++ b/RazorSvelte/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+        "*.cshtml": "${basename}.cshtml.cs, ${basename}.entry.ts, ${basename}.rollup.config.js"
+    }
+}


### PR DESCRIPTION
It's already mentioned in the README and is the default on Visual Studio and Rider, so I think its nice to nest the items by default.